### PR TITLE
Fix Togo alpha3 code

### DIFF
--- a/src/Cosmos.I18N.Countries/Cosmos/I18N/Countries/Africa/Togo.cs
+++ b/src/Cosmos.I18N.Countries/Cosmos/I18N/Countries/Africa/Togo.cs
@@ -14,7 +14,7 @@ namespace Cosmos.I18N.Countries.Africa {
                 BeongsToCountry = Country.Togo,
                 UNCode = "768",
                 Alpha2Code = "TG",
-                Alpha3Code = "AGO",
+                Alpha3Code = "TGO",
                 Name = "The Republic of Togo",
                 ShorterForm = "Togo",
                 ChineseName = "多哥共和国",


### PR DESCRIPTION
Little mistake on Togo Alpha3 code (AGO -> TGO) since AGO is Angola Alpha3 code 